### PR TITLE
chore(ovos-skill-speedtest): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 speedtest-cli
-ovos_workshop>=0.0.12,<8.0.0
+ovos-workshop>=0.0.12,<9.0.0


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0