### PR TITLE
fix: allow ovos-workshop 9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.9"
 dependencies = [
     "ovos-plugin-manager>=2.1.0,<3.0.0",
     "speedtest-cli",
-    "ovos-workshop>=0.0.12,<9.0.0",
+    "ovos-workshop>=0.0.12,<10.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
ovos-core 2.5.0a2 requires `ovos-workshop>=9.0.2a1`; this repo's `<9.0.0` cap is one of 24 blocking the auto-generated constraints-alpha from resolving latest workshop (caught by raspOVOS's new Tier 2 `pip check` gate, which found shipped images with a broken dep graph). Cap bumped to `<10.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)